### PR TITLE
Thorlabs flip mount driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ bootstrap.*
 
 # Mac OSX
 .DS_Store
+
+# IDE
+.vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,13 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "voxel"
-authors = [{name = "Micah Woodard", email = "micah.woodard@alleninstitute.org"}, {name = "Adam Glaser", email = "adam.glaser@alleninstitute.org"}]
+authors = [
+    { name = "Micah Woodard", email = "micah.woodard@alleninstitute.org" },
+    { name = "Adam Glaser", email = "adam.glaser@alleninstitute.org" },
+]
 version = "0.0.0"
 dynamic = ["description"]
-description-file='README.md'
+description-file = 'README.md'
 dependencies = [
     'pyserial >= 3.5',
     'ruamel-yaml >= 0.18.5',
@@ -24,5 +27,7 @@ dependencies = [
     'scikit-tensor-py3',
     'tensorstore >= 0.1.56',
     'pyclesperanto >= 0.8.2',
-    'pylablib >= 1.4.2'
+    'pylablib >= 1.4.2',
+    'tigerasi >= 0.0.26',
+    'pydantic >= 2.7.3',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     'tensorstore >= 0.1.56',
     'pyclesperanto >= 0.8.2',
     'pylablib >= 1.4.2',
+    'inflection >= 0.5.1',
     'tigerasi >= 0.0.26',
     'pydantic >= 2.7.3',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "voxel"
 authors = [
     { name = "Micah Woodard", email = "micah.woodard@alleninstitute.org" },
     { name = "Adam Glaser", email = "adam.glaser@alleninstitute.org" },
+    { name = "Walter Mwaniki", email = "walter.mwaniki@alleninstitute.org" },
 ]
 version = "0.0.0"
 dynamic = ["description"]

--- a/tests/devices/flip_mount/test_simulated.py
+++ b/tests/devices/flip_mount/test_simulated.py
@@ -1,0 +1,64 @@
+import pytest
+from voxel.devices.flip_mount import SimulatedFlipMount
+
+POSITIONS = {
+    'A': 0,
+    'B': 1,
+}
+
+@pytest.fixture
+def simulated():
+    fm = SimulatedFlipMount(
+            id='flip-mount-1',
+            conn='simulated',
+            positions=POSITIONS
+        )
+    yield fm
+    fm.disconnect()
+
+def test_connect(simulated):
+    assert simulated._inst is not None
+    simulated.wait()
+    assert simulated.position ==  next(iter(POSITIONS.keys()))
+
+def test_disconnect(simulated):
+    simulated.disconnect()
+    assert simulated._inst is None
+
+def test_position(simulated):
+    simulated.position = 'B'
+    simulated.wait()
+    assert simulated.position == 'B'
+
+    simulated.position = 'A'
+    simulated.wait()
+    assert simulated.position == 'A'
+
+def test_toggle(simulated):
+    def next_pos(curr):
+        return next(key for key in POSITIONS.keys() if key != curr)
+
+    for _ in range(4):
+        current_pos = simulated.position
+        simulated.toggle(wait=True)
+        current_pos = next_pos(current_pos)
+        assert simulated.position == current_pos
+        simulated.log.info(f'Flip mount {simulated.id} toggled to position {current_pos}')
+
+def test_flip_time(simulated):
+    assert simulated.flip_time_ms == 500.0 # default switch time
+
+    simulated.flip_time_ms = 1000.0
+    assert simulated.flip_time_ms == 1000.0
+
+    simulated.flip_time_ms = 2800.0
+    assert simulated.flip_time_ms == 2800.0
+
+    simulated.flip_time_ms = 100.0
+    assert simulated.flip_time_ms == 500.0
+
+    simulated.flip_time_ms = 2900.0
+    assert simulated.flip_time_ms == 2800.0
+
+    with pytest.raises(TypeError):
+        simulated.flip_time_ms = '1000.0'

--- a/tests/devices/flip_mount/test_thorlabs_mff101.py
+++ b/tests/devices/flip_mount/test_thorlabs_mff101.py
@@ -1,3 +1,4 @@
+import time
 from typing import Literal
 import pytest
 from voxel.devices.flip_mount.thorlabs_mff101 import ThorlabsMFF101
@@ -9,10 +10,16 @@ positions: dict[str, Literal[0, 1]] = {
 
 @pytest.fixture
 def mff101():
-    fm = ThorlabsMFF101(id="flip-mount-1", address='12345678', positions=positions)
+    fm = ThorlabsMFF101(id="flip-mount-1", address='37007737', positions=positions)
     fm.connect()
     yield fm
     fm.disconnect()
+
+def test_connect(mff101):
+    assert mff101.inst is not None
+    time.sleep(1.0)
+    assert mff101.inst.get_state() == 0
+    assert mff101.switch_time_ms == 1000.0
 
 def test_position(mff101):
     assert mff101.position == 'A' # initial position
@@ -22,18 +29,23 @@ def test_position(mff101):
     assert mff101.position == 'A'
 
 def test_toggle(mff101):
-    assert mff101.position == 'A' # initial position
+    mff101.position = 'A'
+    assert mff101.position == 'A'
+
     mff101.toggle()
     assert mff101.position == 'B'
+
+    time.sleep(0.5)
+
     mff101.toggle()
     assert mff101.position == 'A'
 
 def test_switch_time_ms(mff101):
-    assert mff101.switch_time_ms == 10.0 # default switch time
-    mff101.switch_time_ms = 5.0
-    assert mff101.switch_time_ms == 5.0
-    mff101.switch_time_ms = 10.0
-    assert mff101.switch_time_ms == 10.0
+    assert mff101.switch_time_ms == 1000.0 # default switch time
+    mff101.switch_time_ms = 500.0
+    assert mff101.switch_time_ms == 500.0
+    mff101.switch_time_ms = 1000.0
+    assert mff101.switch_time_ms == 1000.0
 
 def test_invalid_position(mff101):
     with pytest.raises(ValueError):
@@ -49,10 +61,25 @@ def test_invalid_switch_time(mff101):
     with pytest.raises(ValueError):
         mff101.switch_time_ms = None
 
-def test_toggle_while_transitioning(mff101):
-    mff101.switch_time_ms = 0.1 * 1e3
-    mff101.position = 'B'
+def test_fast_switch(mff101):
+    mff101.position = 'A'
+    time.sleep(2)
+
+    cycles = 5
+    switch_times = [250]
+    for switch_time in switch_times:
+        for _ in range(cycles):
+            mff101.switch_time_ms = switch_time
+
+            mff101.toggle()
+            assert mff101.position == 'B'
+            time.sleep(0.05)
+
+            mff101.toggle()
+            assert mff101.position == 'A'
+
+    time.sleep(1.0)
+    mff101.switch_time_ms = 105
     mff101.toggle()
+    time.sleep(0.15)
     assert mff101.position == 'B'
-    mff101.toggle()
-    assert mff101.position == 'A'

--- a/tests/devices/flip_mount/test_thorlabs_mff101.py
+++ b/tests/devices/flip_mount/test_thorlabs_mff101.py
@@ -1,16 +1,27 @@
 import time
 from typing import Literal
 import pytest
-from voxel.devices.flip_mount.thorlabs_mff101 import ThorlabsMFF101
+from voxel.devices.flip_mount import FlipMountConfig, ThorlabsMFF101
 
 positions: dict[str, Literal[0, 1]] = {
     'A': 0,
-    'B': 1
+    'B': 1,
 }
+
+mff101_config = FlipMountConfig(
+    id='flip-mount-1',
+    conn='37007737',
+    positions={
+        'A': 0,
+        'B': 1,
+    },
+    init_pos='A',
+    init_flip_time_ms=1000.0,
+)
 
 @pytest.fixture
 def mff101():
-    fm = ThorlabsMFF101(id="flip-mount-1", address='37007737', positions=positions)
+    fm = ThorlabsMFF101(mff101_config)
     fm.connect()
     yield fm
     fm.disconnect()
@@ -19,7 +30,7 @@ def test_connect(mff101):
     assert mff101.inst is not None
     time.sleep(1.0)
     assert mff101.inst.get_state() == 0
-    assert mff101.switch_time_ms == 1000.0
+    assert mff101.flip_time_ms == 500.0
 
 def test_position(mff101):
     assert mff101.position == 'A' # initial position
@@ -40,26 +51,26 @@ def test_toggle(mff101):
     mff101.toggle()
     assert mff101.position == 'A'
 
-def test_switch_time_ms(mff101):
-    assert mff101.switch_time_ms == 1000.0 # default switch time
-    mff101.switch_time_ms = 500.0
-    assert mff101.switch_time_ms == 500.0
-    mff101.switch_time_ms = 1000.0
-    assert mff101.switch_time_ms == 1000.0
+def test_flip_time_ms(mff101):
+    assert mff101.flip_time_ms == 1000.0 # default switch time
+    mff101.flip_time_ms = 500.0
+    assert mff101.flip_time_ms == 500.0
+    mff101.flip_time_ms = 1000.0
+    assert mff101.flip_time_ms == 1000.0
 
 def test_invalid_position(mff101):
     with pytest.raises(ValueError):
         mff101.position = 'C'
 
-def test_invalid_switch_time(mff101):
+def test_invalid_flip_time(mff101):
     with pytest.raises(ValueError):
-        mff101.switch_time_ms = 0.0
+        mff101.flip_time_ms = 0.0
     with pytest.raises(ValueError):
-        mff101.switch_time_ms = -1.0
+        mff101.flip_time_ms = -1.0
     with pytest.raises(ValueError):
-        mff101.switch_time_ms = '5.0'
+        mff101.flip_time_ms = '5.0'
     with pytest.raises(ValueError):
-        mff101.switch_time_ms = None
+        mff101.flip_time_ms = None
 
 def test_fast_switch(mff101):
     mff101.position = 'A'
@@ -69,7 +80,7 @@ def test_fast_switch(mff101):
     switch_times = [250]
     for switch_time in switch_times:
         for _ in range(cycles):
-            mff101.switch_time_ms = switch_time
+            mff101.flip_time_ms = switch_time
 
             mff101.toggle()
             assert mff101.position == 'B'
@@ -79,7 +90,7 @@ def test_fast_switch(mff101):
             assert mff101.position == 'A'
 
     time.sleep(1.0)
-    mff101.switch_time_ms = 105
+    mff101.flip_time_ms = 105
     mff101.toggle()
     time.sleep(0.15)
     assert mff101.position == 'B'

--- a/tests/devices/flip_mount/test_thorlabs_mff101.py
+++ b/tests/devices/flip_mount/test_thorlabs_mff101.py
@@ -1,16 +1,58 @@
-from voxel.devices.flip_mount.thorlabs_mff101 import FlipMount
+from typing import Literal
+import pytest
+from voxel.devices.flip_mount.thorlabs_mff101 import ThorlabsMFF101
 
-positions = {
+positions: dict[str, Literal[0, 1]] = {
     'A': 0,
     'B': 1
 }
-serial_num = 37007737
-flip_mount = FlipMount(serial_num, positions)
-print(flip_mount.switch_time_ms)
-flip_mount.switch_time_ms = 2000
-print(flip_mount.switch_time_ms)
-print(flip_mount.position)
-flip_mount.position = 'B'
-print(flip_mount.position)
-flip_mount.position = 'A'
-print(flip_mount.position)
+
+@pytest.fixture
+def mff101():
+    fm = ThorlabsMFF101(id="flip-mount-1", address='12345678', positions=positions)
+    fm.connect()
+    yield fm
+    fm.disconnect()
+
+def test_position(mff101):
+    assert mff101.position == 'A' # initial position
+    mff101.position = 'B'
+    assert mff101.position == 'B'
+    mff101.position = 'A'
+    assert mff101.position == 'A'
+
+def test_toggle(mff101):
+    assert mff101.position == 'A' # initial position
+    mff101.toggle()
+    assert mff101.position == 'B'
+    mff101.toggle()
+    assert mff101.position == 'A'
+
+def test_switch_time_ms(mff101):
+    assert mff101.switch_time_ms == 10.0 # default switch time
+    mff101.switch_time_ms = 5.0
+    assert mff101.switch_time_ms == 5.0
+    mff101.switch_time_ms = 10.0
+    assert mff101.switch_time_ms == 10.0
+
+def test_invalid_position(mff101):
+    with pytest.raises(ValueError):
+        mff101.position = 'C'
+
+def test_invalid_switch_time(mff101):
+    with pytest.raises(ValueError):
+        mff101.switch_time_ms = 0.0
+    with pytest.raises(ValueError):
+        mff101.switch_time_ms = -1.0
+    with pytest.raises(ValueError):
+        mff101.switch_time_ms = '5.0'
+    with pytest.raises(ValueError):
+        mff101.switch_time_ms = None
+
+def test_toggle_while_transitioning(mff101):
+    mff101.switch_time_ms = 0.1 * 1e3
+    mff101.position = 'B'
+    mff101.toggle()
+    assert mff101.position == 'B'
+    mff101.toggle()
+    assert mff101.position == 'A'

--- a/tests/devices/flip_mount/test_thorlabs_mff101.py
+++ b/tests/devices/flip_mount/test_thorlabs_mff101.py
@@ -1,17 +1,12 @@
-import time
-from typing import Literal
 import pytest
 from voxel.devices.flip_mount import FlipMountConfig, ThorlabsMFF101
 from voxel.devices.flip_mount.thorlabs_mff101 import FLIP_TIME_RANGE
 
-positions: dict[str, Literal[0, 1]] = {
-    'A': 0,
-    'B': 1,
-}
+CONN = '37007737'
 
 mff101_config = FlipMountConfig(
     id='flip-mount-1',
-    conn='37007737',
+    conn=CONN,
     positions={
         'A': 0,
         'B': 1,
@@ -33,25 +28,29 @@ def test_connect(mff101):
     assert mff101.position == mff101_config.init_pos
     assert mff101.flip_time_ms == mff101_config.init_flip_time_ms
 
+def test_disconnect(mff101):
+    mff101.disconnect()
+    assert mff101._inst is None
+
 def test_position(mff101):
     mff101.wait()
     assert mff101.position == 'A'
-    mff101.position = 'B'
-    mff101.wait()
+
+    mff101.position = ('B', True)
     assert mff101.position == 'B'
-    mff101.position = 'A'
+
+    mff101.position = ('A', True)
+    assert mff101.position == 'A'
+
+def test_toggle(mff101):
     mff101.wait()
     assert mff101.position == 'A'
 
-# def test_toggle(mff101):
-#     mff101.wait()
-#     assert mff101.position == 'A'
-#     mff101.toggle(wait=True)
-#     mff101.wait()
-#     assert mff101.position == 'B'
-#     mff101.toggle(wait=True)
-#     mff101.wait()
-#     assert mff101.position == 'A'
+    mff101.toggle(wait=True)
+    assert mff101.position == 'B'
+
+    mff101.toggle(wait=True)
+    assert mff101.position == 'A'
 
 def test_invalid_position(mff101):
     with pytest.raises(ValueError):
@@ -72,10 +71,8 @@ def test_invalid_flip_time(mff101):
     mff101.flip_time_ms = FLIP_TIME_RANGE[1] + 1
     assert mff101.flip_time_ms == FLIP_TIME_RANGE[1]
 
-
 def test_different_switch_times(mff101):
-    mff101.position = 'A'
-    mff101.wait()
+    mff101.position = ('A', True)
 
     cycles = 5
     switch_times = [500, 1000, 1500, 2000, 2500, 2800]
@@ -83,10 +80,43 @@ def test_different_switch_times(mff101):
         mff101.flip_time_ms = switch_time
         for _ in range(cycles):
 
-            mff101.toggle()
-            mff101.wait()
+            mff101.toggle(wait=True)
             assert mff101.position == 'B'
 
-            mff101.toggle()
-            mff101.wait()
+            mff101.toggle(wait=True)
             assert mff101.position == 'A'
+
+def test_reset(mff101):
+    mff101.flip_time_ms = 2101
+    mff101.position = ('B', True)
+    mff101.reset()
+    assert mff101.position == 'A'
+    assert mff101.flip_time_ms == 1000
+
+# Test invalid positions
+def test_invalid_positions():
+    with pytest.raises(ValueError):
+        # Invalid position value
+        FlipMountConfig(
+            id='flip-mount-1',
+            conn=CONN,
+            positions={
+                'A': 0,
+                'B': 2,
+            },
+            init_pos='A',
+            init_flip_time_ms=1000,
+        )
+
+    with pytest.raises(ValueError):
+        # Invalid init_pos
+        FlipMountConfig(
+            id='flip-mount-1',
+            conn=CONN,
+            positions={
+                'A': 0,
+                'B': 1,
+            },
+            init_pos='C',
+            init_flip_time_ms=1000,
+        )

--- a/tests/devices/flip_mount/test_thorlabs_mff101.py
+++ b/tests/devices/flip_mount/test_thorlabs_mff101.py
@@ -1,6 +1,6 @@
 import time
 import pytest
-from voxel.devices.flip_mount import FlipMountConfig, ThorlabsMFF101
+from voxel.devices.flip_mount import ThorlabsFlipMount
 from voxel.devices.flip_mount.thorlabs_mff101 import FLIP_TIME_RANGE
 
 CONN = '37007737'
@@ -8,17 +8,13 @@ POSITIONS = {
     'A': 0,
     'B': 1,
 }
-INIT_POS = 'A'
-INIT_FLIPTIME = 1000
 
 @pytest.fixture
 def mff101():
-    fm = ThorlabsMFF101(
+    fm = ThorlabsFlipMount(
             id='flip-mount-1',
             conn=CONN,
-            positions=POSITIONS,
-            init_pos=INIT_POS,
-            init_flip_time_ms=INIT_FLIPTIME
+            positions=POSITIONS
         )
     yield fm
     fm.disconnect()
@@ -26,8 +22,7 @@ def mff101():
 def test_connect(mff101):
     assert mff101._inst is not None
     mff101.wait()
-    assert mff101.position == INIT_POS
-    assert mff101.flip_time_ms == INIT_FLIPTIME
+    assert mff101.position ==  next(iter(POSITIONS.keys()))
 
 def test_disconnect(mff101):
     mff101.disconnect()
@@ -91,15 +86,3 @@ def test_different_switch_times(mff101):
             time.sleep(1)
             mff101.toggle(wait=True)
             assert mff101.position == 'A'
-
-def test_reset(mff101):
-    mff101.flip_time_ms = 500
-    mff101.position = 'B'
-    mff101.wait()
-    assert mff101.position == 'B'
-    assert mff101.flip_time_ms == 500
-
-    mff101.reset()
-    mff101.wait()
-    assert mff101.position == 'A'
-    assert mff101.flip_time_ms == 1000

--- a/tests/devices/flip_mount/test_thorlabs_mff101.py
+++ b/tests/devices/flip_mount/test_thorlabs_mff101.py
@@ -4,29 +4,30 @@ from voxel.devices.flip_mount import FlipMountConfig, ThorlabsMFF101
 from voxel.devices.flip_mount.thorlabs_mff101 import FLIP_TIME_RANGE
 
 CONN = '37007737'
-
-mff101_config = FlipMountConfig(
-    id='flip-mount-1',
-    conn=CONN,
-    positions={
-        'A': 0,
-        'B': 1,
-    },
-    init_pos='A',
-    init_flip_time_ms=1000,
-)
+POSITIONS = {
+    'A': 0,
+    'B': 1,
+}
+INIT_POS = 'A'
+INIT_FLIPTIME = 1000
 
 @pytest.fixture
 def mff101():
-    fm = ThorlabsMFF101(mff101_config)
+    fm = ThorlabsMFF101(
+            id='flip-mount-1',
+            conn=CONN,
+            positions=POSITIONS,
+            init_pos=INIT_POS,
+            init_flip_time_ms=INIT_FLIPTIME
+        )
     yield fm
     fm.disconnect()
 
 def test_connect(mff101):
     assert mff101._inst is not None
     mff101.wait()
-    assert mff101.position == mff101_config.init_pos
-    assert mff101.flip_time_ms == mff101_config.init_flip_time_ms
+    assert mff101.position == INIT_POS
+    assert mff101.flip_time_ms == INIT_FLIPTIME
 
 def test_disconnect(mff101):
     mff101.disconnect()

--- a/voxel/descriptors/deliminated_property.py
+++ b/voxel/descriptors/deliminated_property.py
@@ -15,7 +15,7 @@ class _DeliminatedProperty(property):
         self._fset = fset
         self._fdel = fdel
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, owner=None):
         if instance is None:
             return self
         return self._fget(instance)
@@ -34,6 +34,10 @@ class _DeliminatedProperty(property):
 
     def __set_name__(self, owner, name):
         self._name = f'_{name}'
+
+    def __call__(self, func):
+        self._fget = func
+        return self
 
     def setter(self, fset):
         return type(self)(self._fget, fset, self._fdel, self.minimum, self.maximum, self.step)

--- a/voxel/devices/flip_mount/__init__.py
+++ b/voxel/devices/flip_mount/__init__.py
@@ -4,3 +4,11 @@ Flip mount device classes
 
 from .base import BaseFlipMount, FlipMountConfig
 from .thorlabs_mff101 import ThorlabsMFF101
+from .simulated import SimulatedFlipMount
+
+__all__ = [
+    'BaseFlipMount',
+    'FlipMountConfig',
+    'ThorlabsMFF101',
+    'SimulatedFlipMount',
+]

--- a/voxel/devices/flip_mount/__init__.py
+++ b/voxel/devices/flip_mount/__init__.py
@@ -1,0 +1,6 @@
+"""
+Flip mount device classes
+"""
+
+from .base import BaseFlipMount, FlipMountConfig
+from .thorlabs_mff101 import ThorlabsMFF101

--- a/voxel/devices/flip_mount/__init__.py
+++ b/voxel/devices/flip_mount/__init__.py
@@ -1,14 +1,13 @@
 """
-Flip mount device classes
+Flip mount device classes for the Voxel Library.
 """
 
-from .base import BaseFlipMount, FlipMountConfig
-from .thorlabs_mff101 import ThorlabsMFF101
+from .base import BaseFlipMount
+from .thorlabs_mff101 import ThorlabsFlipMount
 from .simulated import SimulatedFlipMount
 
 __all__ = [
     'BaseFlipMount',
-    'FlipMountConfig',
-    'ThorlabsMFF101',
+    'ThorlabsFlipMount',
     'SimulatedFlipMount',
 ]

--- a/voxel/devices/flip_mount/base.py
+++ b/voxel/devices/flip_mount/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import logging
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 class FlipMountConfig(BaseModel):
     id: str
@@ -11,11 +11,17 @@ class FlipMountConfig(BaseModel):
     init_pos: str
     init_flip_time_ms: int
 
+    @field_validator('init_pos')
+    def init_pos_must_be_in_positions(cls, init_pos, values):
+        positions = values.get('positions')
+        if positions is not None and init_pos not in positions:
+            raise ValueError(f'init_pos {init_pos} is not a key in positions dictionary')
+        return init_pos
+
 class BaseFlipMount(ABC):
     def __init__(self, id: str):
         self.id = id
         self.log = logging.getLogger(__name__ + "." + self.__class__.__name__)
-
 
     @abstractmethod
     def connect(self):
@@ -30,7 +36,7 @@ class BaseFlipMount(ABC):
     @property
     @abstractmethod
     def position(self) -> str | None:
-        """Return the current position of the flip mount."""
+        """Position of the flip mount."""
         pass
 
     @position.setter
@@ -40,14 +46,21 @@ class BaseFlipMount(ABC):
 
     @abstractmethod
     def toggle(self):
+        """Toggle the flip mount position """
         pass
 
     @property
     @abstractmethod
     def flip_time_ms(self) -> int:
+        """Time it takes to flip the mount in milliseconds."""
         pass
 
     @flip_time_ms.setter
     @abstractmethod
     def flip_time_ms(self, time_ms: int):
         pass
+
+    def __del__(self):
+            self.disconnect()
+
+# Path: voxel/devices/flip_mount/thorlabs_mff101.py

--- a/voxel/devices/flip_mount/base.py
+++ b/voxel/devices/flip_mount/base.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
 import logging
+import re
 from typing import Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, model_validator
 
 class FlipMountConfig(BaseModel):
     id: str
@@ -11,12 +12,11 @@ class FlipMountConfig(BaseModel):
     init_pos: str
     init_flip_time_ms: int
 
-    @field_validator('init_pos')
-    def init_pos_must_be_in_positions(cls, init_pos, values):
-        positions = values.get('positions')
-        if positions is not None and init_pos not in positions:
-            raise ValueError(f'init_pos {init_pos} is not a key in positions dictionary')
-        return init_pos
+    @model_validator(mode="after")
+    def init_pos_must_be_in_positions(self):
+        if self.init_pos not in self.positions:
+            raise ValueError(f"init_pos must be one of {self.positions.keys()}")
+        return self
 
 class BaseFlipMount(ABC):
     def __init__(self, id: str):

--- a/voxel/devices/flip_mount/base.py
+++ b/voxel/devices/flip_mount/base.py
@@ -1,22 +1,5 @@
 from abc import ABC, abstractmethod
 import logging
-import re
-from typing import Literal
-
-from pydantic import BaseModel, model_validator
-
-class FlipMountConfig(BaseModel):
-    id: str
-    conn: str
-    positions: dict[str, Literal[0, 1]]
-    init_pos: str
-    init_flip_time_ms: int
-
-    @model_validator(mode="after")
-    def init_pos_must_be_in_positions(self):
-        if self.init_pos not in self.positions:
-            raise ValueError(f"init_pos must be one of {self.positions.keys()}")
-        return self
 
 class BaseFlipMount(ABC):
     def __init__(self, id: str):

--- a/voxel/devices/flip_mount/base.py
+++ b/voxel/devices/flip_mount/base.py
@@ -9,7 +9,7 @@ class FlipMountConfig(BaseModel):
     conn: str
     positions: dict[str, Literal[0, 1]]
     init_pos: str
-    init_flip_time_ms: float
+    init_flip_time_ms: int
 
 class BaseFlipMount(ABC):
     def __init__(self, id: str):
@@ -44,10 +44,10 @@ class BaseFlipMount(ABC):
 
     @property
     @abstractmethod
-    def flip_time_ms(self) -> float:
+    def flip_time_ms(self) -> int:
         pass
 
     @flip_time_ms.setter
     @abstractmethod
-    def flip_time_ms(self, time_ms: float):
+    def flip_time_ms(self, time_ms: int):
         pass

--- a/voxel/devices/flip_mount/base.py
+++ b/voxel/devices/flip_mount/base.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+import logging
+
+class BaseFlipMount(ABC):
+    def __init__(self, id: str):
+        self.id = id
+        self.log = logging.getLogger(__name__ + "." + self.__class__.__name__)
+
+
+    @abstractmethod
+    def connect(self):
+        """Connect to the flip mount."""
+        pass
+
+    @abstractmethod
+    def disconnect(self):
+        """Disconnect from the flip mount."""
+        pass
+
+    @property
+    @abstractmethod
+    def position(self) -> str:
+        """Return the current position of the flip mount."""
+        pass
+
+    @position.setter
+    @abstractmethod
+    def position(self, position_name: str, wait=False):
+        pass
+
+    @abstractmethod
+    def toggle(self):
+        pass
+
+    @property
+    @abstractmethod
+    def switch_time_ms(self) -> float:
+        pass
+
+    @switch_time_ms.setter
+    @abstractmethod
+    def switch_time_ms(self, time_ms: float):
+        pass

--- a/voxel/devices/flip_mount/base.py
+++ b/voxel/devices/flip_mount/base.py
@@ -1,5 +1,15 @@
 from abc import ABC, abstractmethod
 import logging
+from typing import Literal
+
+from pydantic import BaseModel
+
+class FlipMountConfig(BaseModel):
+    id: str
+    conn: str
+    positions: dict[str, Literal[0, 1]]
+    init_pos: str
+    init_flip_time_ms: float
 
 class BaseFlipMount(ABC):
     def __init__(self, id: str):
@@ -19,7 +29,7 @@ class BaseFlipMount(ABC):
 
     @property
     @abstractmethod
-    def position(self) -> str:
+    def position(self) -> str | None:
         """Return the current position of the flip mount."""
         pass
 
@@ -34,10 +44,10 @@ class BaseFlipMount(ABC):
 
     @property
     @abstractmethod
-    def switch_time_ms(self) -> float:
+    def flip_time_ms(self) -> float:
         pass
 
-    @switch_time_ms.setter
+    @flip_time_ms.setter
     @abstractmethod
-    def switch_time_ms(self, time_ms: float):
+    def flip_time_ms(self, time_ms: float):
         pass

--- a/voxel/devices/flip_mount/simulated.py
+++ b/voxel/devices/flip_mount/simulated.py
@@ -1,0 +1,48 @@
+from . import BaseFlipMount, FlipMountConfig
+
+class SimulatedFlipMount(BaseFlipMount):
+    def __init__(self, config: FlipMountConfig):
+        super().__init__(config.id)
+        self._conn = config.conn
+        self._positions = config.positions
+        self._init_pos = config.init_pos
+        self._init_flip_time_ms = config.init_flip_time_ms
+        self._inst = None
+        self.connect()
+
+    def connect(self):
+        self.reset()
+
+    def reset(self):
+        self.position = self._init_pos
+        self.flip_time_ms = self._init_flip_time_ms
+
+    def disconnect(self):
+        self._inst = None
+
+    def wait(self):
+        pass
+
+    def toggle(self, wait=False):
+        new_pos = 0 if self._inst == 1 else 1
+        self._inst = new_pos
+        if wait:
+            self.wait()
+
+    @property
+    def position(self):
+        return next((key for key, value in self._positions.items() if value == self._inst), 'Unknown')
+
+    @position.setter
+    def position(self, position_name, wait=False):
+        self._inst = self._positions[position_name]
+        if wait:
+            self.wait()
+
+    @property
+    def flip_time_ms(self):
+        return self._flip_time_ms
+
+    @flip_time_ms.setter
+    def flip_time_ms(self, time_ms):
+        self._flip_time_ms = time_ms

--- a/voxel/devices/flip_mount/simulated.py
+++ b/voxel/devices/flip_mount/simulated.py
@@ -1,12 +1,12 @@
 from . import BaseFlipMount, FlipMountConfig
 
 class SimulatedFlipMount(BaseFlipMount):
-    def __init__(self, config: FlipMountConfig):
-        super().__init__(config.id)
-        self._conn = config.conn
-        self._positions = config.positions
-        self._init_pos = config.init_pos
-        self._init_flip_time_ms = config.init_flip_time_ms
+    def __init__(self, id, conn, positions, init_pos, init_flip_time_ms):
+        super().__init__(id)
+        self._conn = conn
+        self._positions = positions
+        self._init_pos = init_pos
+        self._init_flip_time_ms = init_flip_time_ms
         self._inst = None
         self.connect()
 

--- a/voxel/devices/flip_mount/simulated.py
+++ b/voxel/devices/flip_mount/simulated.py
@@ -1,27 +1,28 @@
-from . import BaseFlipMount, FlipMountConfig
+from time import sleep
+from typing import Literal
+
+from ...descriptors.deliminated_property import DeliminatedProperty
+from . import BaseFlipMount
+
+FLIP_TIME_RANGE_MS: tuple[float, float] = (500.0, 2800.0, 100.0) # min, max, step
 
 class SimulatedFlipMount(BaseFlipMount):
-    def __init__(self, id, conn, positions, init_pos, init_flip_time_ms):
+    def __init__(self, id, conn, positions):
         super().__init__(id)
         self._conn = conn
         self._positions = positions
-        self._init_pos = init_pos
-        self._init_flip_time_ms = init_flip_time_ms
-        self._inst = None
+        self._inst: Literal[0, 1] = None
         self.connect()
 
     def connect(self):
-        self.reset()
-
-    def reset(self):
-        self.position = self._init_pos
-        self.flip_time_ms = self._init_flip_time_ms
+        self.position = next(iter(self._positions)) # set to first position
+        self.flip_time_ms: float = FLIP_TIME_RANGE_MS[0] # min flip time
 
     def disconnect(self):
         self._inst = None
 
     def wait(self):
-        pass
+        sleep(self.flip_time_ms * 1e-3)
 
     def toggle(self, wait=False):
         new_pos = 0 if self._inst == 1 else 1
@@ -30,19 +31,24 @@ class SimulatedFlipMount(BaseFlipMount):
             self.wait()
 
     @property
-    def position(self):
+    def position(self) -> str:
         return next((key for key, value in self._positions.items() if value == self._inst), 'Unknown')
 
     @position.setter
-    def position(self, position_name, wait=False):
-        self._inst = self._positions[position_name]
-        if wait:
-            self.wait()
+    def position(self, new_position):
+        try:
+            self._inst = self._positions[new_position]
+        except KeyError:
+            raise ValueError(f'Invalid position {new_position}. Valid positions are {list(self._positions.keys())}')
+        except Exception as e:
+            raise e
 
-    @property
-    def flip_time_ms(self):
+    @DeliminatedProperty(minimum=FLIP_TIME_RANGE_MS[0], maximum=FLIP_TIME_RANGE_MS[1], step=FLIP_TIME_RANGE_MS[2])
+    def flip_time_ms(self) -> float:
         return self._flip_time_ms
 
     @flip_time_ms.setter
-    def flip_time_ms(self, time_ms):
+    def flip_time_ms(self, time_ms: float):
+        print(f"Setting flip_time_ms to {time_ms}")
+        print(f"FLIP_TIME_RANGE_MS is {FLIP_TIME_RANGE_MS}")
         self._flip_time_ms = time_ms

--- a/voxel/devices/flip_mount/thorlabs_mff101.py
+++ b/voxel/devices/flip_mount/thorlabs_mff101.py
@@ -11,13 +11,13 @@ FLIP_TIME_RANGE = (500, 2800)
 
 
 class ThorlabsMFF101(BaseFlipMount):
-    def __init__(self, config: FlipMountConfig):
-        super().__init__(config.id)
-        self._conn = config.conn
-        self._positions = config.positions
+    def __init__(self, id, conn, positions, init_pos, init_flip_time_ms):
+        super().__init__(id)
+        self._conn = conn
+        self._positions = positions
         self._inst: Optional[Thorlabs.MFF] = None
-        self._init_pos = config.init_pos
-        self._init_flip_time_ms = config.init_flip_time_ms
+        self._init_pos = init_pos
+        self._init_flip_time_ms = init_flip_time_ms
         self.connect()
 
     def connect(self):

--- a/voxel/devices/flip_mount/thorlabs_mff101.py
+++ b/voxel/devices/flip_mount/thorlabs_mff101.py
@@ -56,14 +56,13 @@ class ThorlabsMFF101(BaseFlipMount):
         return next((key for key, value in self._positions.items() if value == pos_idx), 'Unknown')
 
     @position.setter
-    def position(self, position_name: str, wait=False):
-        if self._inst is None: raise ValueError('Flip mount not connected')
+    def position(self, position_name: str):
+        if self._inst is None:
+            raise ValueError('Flip mount not connected')
         if position_name not in self._positions:
             raise ValueError(f'Invalid position {position_name}. Valid positions are {list(self._positions.keys())}')
         self._inst.move_to_state(self._positions[position_name])
         self.log.info(f'Flip mount {self.id} moved to position {position_name}')
-        if wait:
-            self.wait()
 
     @DeliminatedProperty(minimum=FLIP_TIME_RANGE[0], maximum=FLIP_TIME_RANGE[1], step=100)
     def flip_time_ms(self) -> int:

--- a/voxel/devices/flip_mount/thorlabs_mff101.py
+++ b/voxel/devices/flip_mount/thorlabs_mff101.py
@@ -1,82 +1,64 @@
-import logging
 import time
 from pylablib.devices import Thorlabs
+from typing import Literal, Optional
+from voxel.devices.flip_mount.base import BaseFlipMount
 
-MIN_SWITCH_TIME_S = 0.3
-MAX_SWITCH_TIME_S = 2.8
 VALID_POSITIONS = [0, 1]
 
+class ThorlabsMFF101(BaseFlipMount):
+    def __init__(self, id: str, address: str, positions: dict[str, Literal[0, 1]]):
+        super().__init__(id)
+        self.address = address
+        self.positions = positions if self.validate_positions(positions) else {}
+        self.inst: Optional[Thorlabs.MFF] = None
 
-class FlipMount:
-    def __init__(self, id: str, positions: dict):
-        self.log = logging.getLogger(__name__ + "." + self.__class__.__name__)
-        self.id = id  # serial number of flip mount
-        self.positions = positions   # dict of names and their positions
-        # check that all positions are valid
-        if not all([pos in VALID_POSITIONS
-                    for _,pos in self.positions.items()]):
-            raise ValueError(f'positions must be {VALID_POSITIONS}')
-        # lets find the device using pyvisa
-        devices = Thorlabs.list_kinesis_devices()
-        # device = [(serial number, name)]
+    @staticmethod
+    def validate_positions(positions: dict) -> bool:
+        if not all([pos in VALID_POSITIONS for pos in positions.values()]):
+            raise ValueError(f'Positions must be {VALID_POSITIONS}')
+        return True
+
+    def connect(self):
         try:
-            for device in devices:
-                # uses the MFF class within
-                # devices/Thorlabs/kinesis of pylablib
-                flip_mount = Thorlabs.MFF(conn=device[0])
-                info = flip_mount.get_device_info()
-                if info.serial_no == id:
-                    self.flip_mount = flip_mount
-                    break
-        except:
-            self.log.debug(f'{id} is not a valid thorabs flip mount')
-            raise ValueError(f'could not find flip mount with id {id}')
+            self.inst = Thorlabs.MFF(conn=self.address)
+            self.inst.move_to_state(list(self.positions.values())[0])
+        except Exception as e:
+            self.log.error(f'Could not connect to flip mount {self.id}: {e}')
+            raise e
+
+    def disconnect(self):
+        if self.inst is not None:
+            self.inst.close()
+            self.inst = None
+            self.log.info(f'Flip mount {self.id} disconnected')
 
     @property
-    def position(self):
-        # returns 0 or 1 for position of flip mount
-        position = self.flip_mount.get_state()
-        return next(key for key, value in
-                    self.positions.items() if value == position)
+    def position(self) -> str:
+        if self.inst is None: raise ValueError('Flip mount not connected')
+        pos_idx =  self.inst.get_state()
+        return next(key for key, value in self.positions.items() if value == pos_idx)
 
     @position.setter
-    def position(self, position_name: str, wait=False):
-        # returns 0 or 1 for position of flip mount
-        if position_name not in self.positions.keys():
-            raise ValueError(f'position {position_name}'
-                             f'not in {self.positions.keys()}')
-        self.flip_mount.move_to_state(self.positions[position_name])
-        self.log.info(f'flip mount {self.id}'
-                      f'moved to position {position_name}')
+    def position(self, position_name: str, wait: bool = False):
+        if self.inst is None: raise ValueError('Flip mount not connected')
+        self.inst.move_to_state(self.positions[position_name])
+        self.log.info(f'Flip mount {self.id} moved to position {position_name}')
         if wait:
             time.sleep(self.switch_time_ms)
-    
+
+    def toggle(self):
+        if self.inst is None: raise ValueError('Flip mount not connected')
+        new_pos = 0 if self.inst.get_state() == 1 else 1
+        self.inst.move_to_state(new_pos)
+
     @property
-    def switch_time_ms(self):
-        # returns the time it takes to switch between states
-        parameters = self.flip_mount.get_flipper_parameters()
-        # returns TFlipperParameters(
-        # transit_time*1E-3, # converted from ms to s
-        # io1_oper_mode,
-        # io1_sig_mode,
-        # io1_pulse_width*1E-3,
-        # io2_oper_mode,
-        # io2_sig_mode,
-        # io2_pulse_width*1E-3)
-        # we only care about the transit time, return in ms
-        return parameters.transit_time*1000
-    
+    def switch_time_ms(self) -> float:
+        if self.inst is None:
+            raise ValueError('Flip mount not connected')
+        parameters = self.inst.get_flipper_parameters()
+        return parameters.transit_time * 1e3
+
     @switch_time_ms.setter
     def switch_time_ms(self, time_ms: float):
-        # set the time it takes to switch between states
-        if time_ms < MIN_SWITCH_TIME_S * 1000 or \
-           time_ms > MAX_SWITCH_TIME_S * 1000:
-            raise ValueError(f'switch time {time_ms} must be <'
-                             f'{MAX_SWITCH_TIME_S} and > {MIN_SWITCH_TIME_S}')
-        self.flip_mount.setup_flipper(transit_time=time_ms/1000)
-        self.log.info(f'flip mount {self.id} switch time set to {time_ms} ms')
-
-    def close(self):
-        # inherited close property from kinesis in pylablib
-        self.close()
-        self.log.info(f'power meter {self.id} closed')
+        if self.inst is None: raise ValueError('Flip mount not connected')
+        self.inst.setup_flipper(transit_time=time_ms/1000)


### PR DESCRIPTION
This merge adds in a simple driver for the ThorlabsMF101 flip mount.  
I used this as a starting point to figure out possible standards we can implement across all devices.
- An abstract base class that uses python's ABC class.
- A device id of type string.
- Connect and disconnect methods.